### PR TITLE
Fixed tuples decoding

### DIFF
--- a/bert.js
+++ b/bert.js
@@ -355,7 +355,7 @@ BertClass.prototype.decode_tuple = function (S, Count) {
 		S = El.rest;
 	}
 	return {
-		value: this.tuple(Arr),
+      value: this.tuple.apply(this,Arr),
 		rest: S
 	};
 };


### PR DESCRIPTION
Before, Bert.decoding(term_to_binary({1,2})) was Bert.tuple([1,2]) and binary_to_term(Bert.encode(Bert.tuple([1,2]))) was {[1,2]} now Bert.decoding(term_to_binary({1,2})) is Bert.tuple(1,2).
