### PR TITLE
Fix decoding small integers. closes #3

### DIFF
--- a/bert.js
+++ b/bert.js
@@ -238,7 +238,7 @@ BertClass.prototype.decode_inner = function (S) {
 	case this.BINARY:
 		return this.decode_binary(S);
 	case this.SMALL_INTEGER:
-		return this.decode_integer(S, 1);
+		return this.decode_small_integer(S);
 	case this.INTEGER:
 		return this.decode_integer(S, 4);
 	case this.SMALL_BIG:
@@ -285,6 +285,15 @@ BertClass.prototype.decode_binary = function (S) {
 	return {
 		value: this.binary(S.substring(0, Size)),
 		rest:  S.substring(Size)
+	};
+};
+
+BertClass.prototype.decode_small_integer = function (S) {
+	var Value = S.charCodeAt(0);
+	S = S.substring(1);
+	return {
+		value: Value,
+		rest:  S
 	};
 };
 

--- a/tests.js
+++ b/tests.js
@@ -124,6 +124,9 @@ describe('Bert')
         expect(Bert.pp_term(term)).toBe('{atom, myAtom},{binary, <<"My Binary">>},{bool, true},{string, Hello there}')
         
     })
+    .should('decode small ints', function(){
+        expect(Bert.decode(Bert.bytes_to_string([131,97,130]))).toBe(130)
+    })
     .should('decode negative ints', function(){
         expect(Bert.decode(Bert.bytes_to_string([131,98,255,255,255,255]))).toBe(-1)
     })


### PR DESCRIPTION
Bert.decode(Bert.encode(130)) was returning -126.
According to http://erlang.org/doc/apps/erts/erl_ext_dist.html#id85118,
small integers are just one unsigned 8 bit integer.